### PR TITLE
Cloudflare Craft - Background job for cache flush

### DIFF
--- a/src/jobs/FlushCFCacheJob.php
+++ b/src/jobs/FlushCFCacheJob.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace workingconcept\cloudflare\jobs;
+
+use Craft;
+use \craft\queue\BaseJob;
+use craft\queue\QueueInterface;
+use workingconcept\cloudflare\Cloudflare;
+use workingconcept\cloudflare\services\Api;
+
+class FlushCFCacheJob extends BaseJob
+{
+    public $urls;
+
+    /**
+     * @param \yii\queue\Queue|QueueInterface $queue
+     * @return mixed|void
+     */
+    public function execute($queue)
+    {
+        Cloudflare::getInstance()->api->purgeUrls($this->urls);
+        $this->setProgress($queue, 100);
+    }
+
+    public function getDescription()
+    {
+        return 'Automaticly flush cloudflare cache';
+    }
+}


### PR DESCRIPTION
This pull request uses a background job to flush the cloudflare cache, instead of slowing down the save event. This causes the admin to work faster. Also checks if the element we are saving is not a draft, to make sure we don't flush the cache when it's not needed.