### PR TITLE
Added localized config support for Zone ID’s

### DIFF
--- a/src/Cloudflare.php
+++ b/src/Cloudflare.php
@@ -316,12 +316,13 @@ class Cloudflare extends Plugin
         }
 
         $className = get_class($element);
+        $siteHandle = $element->getSite()->handle;
 
         if (!$isNew && $this->_shouldPurgeElementType($className)) {
             $url = $this->getAbsoluteUrl($element);
             if ($url !== null) {
                 Queue::push(
-                    new PurgeCloudflareCache(['urls' => [$url]]),
+                    new PurgeCloudflareCache(['urls' => [$url], 'siteHandle' => $siteHandle]),
                     Cloudflare::$plugin->settings->queueJobPriority,
                 );
             }
@@ -329,7 +330,8 @@ class Cloudflare extends Plugin
 
         // Honour any explicit rules that match this URL, regardless of whatever Element it is.
         $this->rules->purgeCachesForUrl(
-            $element->getUrl()
+            $element->getUrl(),
+            $siteHandle,
         );
     }
 
@@ -363,7 +365,7 @@ class Cloudflare extends Plugin
         }
 
         Queue::push(
-            new PurgeCloudflareCache(['urls' => $urls]),
+            new PurgeCloudflareCache(['urls' => $urls, 'siteHandle' => $asset->getSite()->handle]),
             Cloudflare::$plugin->settings->queueJobPriority,
         );
     }

--- a/src/console/controllers/PurgeController.php
+++ b/src/console/controllers/PurgeController.php
@@ -17,8 +17,9 @@ class PurgeController extends Controller
      * https://www.yiiframework.com/doc/guide/2.0/en/tutorial-console#arguments
      *
      * @param string[] $urls
+     * @param string|null $siteHandle
      */
-    public function actionPurgeUrls(array $urls): int
+    public function actionPurgeUrls(array $urls, ?string $siteHandle = null): int
     {
         $urlCount = count($urls);
         $urlWord = $urlCount === 1 ? 'URL' : 'URLs';
@@ -27,7 +28,7 @@ class PurgeController extends Controller
             sprintf('Purging %d %s...', $urlCount, $urlWord) . PHP_EOL
         );
 
-        $response = Cloudflare::$plugin->api->purgeUrls($urls);
+        $response = Cloudflare::$plugin->api->purgeUrls($urls, $siteHandle);
 
         return $this->_handleResult($response);
     }

--- a/src/helpers/ConfigHelper.php
+++ b/src/helpers/ConfigHelper.php
@@ -9,6 +9,7 @@ namespace putyourlightson\cloudflare\helpers;
 use Craft;
 use craft\console\Application as ConsoleApplication;
 use craft\helpers\App;
+use craft\helpers\Cp;
 use putyourlightson\cloudflare\Cloudflare;
 use putyourlightson\cloudflare\models\Settings;
 
@@ -35,7 +36,7 @@ class ConfigHelper
      * parameters if we’re in the control panel checking unsaved settings.
      * Also parses environment variables.
      */
-    public static function getParsedSetting(string $key): ?string
+    public static function getParsedSetting(string $key, ?string $siteHandle = null): ?string
     {
         $request = Craft::$app->getRequest();
         $isConsole = Craft::$app instanceof ConsoleApplication;
@@ -49,8 +50,14 @@ class ConfigHelper
             !empty($request->getParam($key)) &&
             is_string($request->getParam($key));
 
-        $settingValue = $usePost ? $request->getParam($key) :
-            Cloudflare::$plugin->getSettings()->{$key} ?? null;
+        if ($usePost) {
+            $settingValue = $request->getParam($key);
+        } elseif ($key == 'zone') {
+            $siteHandle = $siteHandle ?? Cp::requestedSite()->handle;
+            $settingValue = Cloudflare::$plugin->getSettings()->getZone($siteHandle);
+        } else {
+            $settingValue = Cloudflare::$plugin->getSettings()->{$key} ?? null;
+        }
 
         if ($settingValue) {
             /** @scrutinizer ignore-call */

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -128,7 +128,7 @@ class Settings extends Model
     private function _getStaticConfig(?string $siteHandle = null): array
     {
         $config = Craft::$app->getConfig()->getConfigFromFile('cloudflare');
-        $config['zone'] = ConfigHelper::localizedValue($config['zone'], $siteHandle);
+        $config['zone'] = ConfigHelper::localizedValue($config['zone'] ?? null, $siteHandle);
 
         return $config;
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -4,6 +4,7 @@ namespace putyourlightson\cloudflare\models;
 
 use Craft;
 use craft\base\Model;
+use craft\helpers\ConfigHelper;
 use putyourlightson\cloudflare\Cloudflare;
 
 class Settings extends Model
@@ -40,9 +41,9 @@ class Settings extends Model
     public ?string $apiToken = null;
 
     /**
-     * @var ?string  This site’s related Cloudflare Zone ID.
+     * @var mixed  This site’s related Cloudflare Zone ID.
      */
-    public ?string $zone = null;
+    public mixed $zone = null;
 
     /**
      * @var string[]  List of element type classes that should be purged automatically.
@@ -68,6 +69,14 @@ class Settings extends Model
     public ?int $queueJobPriority = null;
 
     /**
+     * Returns the localized Zone value.
+     */
+    public function getZone(?string $siteHandle = null): ?string
+    {
+        return ConfigHelper::localizedValue($this->zone, $siteHandle);
+    }
+
+    /**
      * Returns `true` if the Cloudflare zone ID is set in a static config file.\
      */
     public function zoneIsStatic(): bool
@@ -91,7 +100,17 @@ class Settings extends Model
         return [
             [['authType'], 'in', 'range' => [self::AUTH_TYPE_KEY, self::AUTH_TYPE_TOKEN]],
             [['purgeElements'], 'each', 'rule' => ['in', 'range' => Cloudflare::$supportedElementTypes]],
-            [['apiKey', 'email', 'apiToken', 'zone', 'zoneName', 'userServiceKey'], 'string'],
+            [['apiKey', 'email', 'apiToken', 'zoneName', 'userServiceKey'], 'string'],
+            [
+                ['zone'], 'string', 'when' => static function ($model) {
+                    return is_string($model->zone);
+                },
+            ],
+            [
+                ['zone'], 'each', 'rule' => ['string'], 'when' => static function ($model) {
+                    return is_array($model->zone);
+                },
+            ],
             ['zone', 'required'],
             [
                 ['apiKey', 'email'], 'required', 'when' => static function($model) {
@@ -106,8 +125,11 @@ class Settings extends Model
         ];
     }
 
-    private function _getStaticConfig(): array
+    private function _getStaticConfig(?string $siteHandle = null): array
     {
-        return Craft::$app->getConfig()->getConfigFromFile('cloudflare');
+        $config = Craft::$app->getConfig()->getConfigFromFile('cloudflare');
+        $config['zone'] = ConfigHelper::localizedValue($config['zone'], $siteHandle);
+
+        return $config;
     }
 }

--- a/src/queue/jobs/PurgeCloudflareCache.php
+++ b/src/queue/jobs/PurgeCloudflareCache.php
@@ -14,11 +14,16 @@ class PurgeCloudflareCache extends BaseJob
     public array $urls;
 
     /**
+     * @var string|null Site handle to be used for purging
+     */
+    public ?string $siteHandle = null;
+
+    /**
      * @inheritdoc
      */
     public function execute($queue): void
     {
-        Cloudflare::$plugin->api->purgeUrls($this->urls);
+        Cloudflare::$plugin->api->purgeUrls($this->urls, $this->siteHandle);
         $this->setProgress($queue, 100);
     }
 

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -265,8 +265,9 @@ class Api extends Component
      * https://developers.cloudflare.com/api/resources/cache/methods/purge/
      *
      * @param string[] $urls array of absolute URLs
+     * @param string|null $siteHandle optional site handle to override the default one
      */
-    public function purgeUrls(array $urls = []): mixed
+    public function purgeUrls(array $urls = [], ?string $siteHandle = null): mixed
     {
         if (!$this->getClient()) {
             return null;
@@ -284,7 +285,7 @@ class Api extends Component
         try {
             $response = $this->getClient()->delete(sprintf(
                 'zones/%s/purge_cache',
-                ConfigHelper::getParsedSetting('zone')
+                ConfigHelper::getParsedSetting('zone', $siteHandle),
             ),
                 ['body' => Json::encode(['files' => $urls])]
             );

--- a/src/services/Rules.php
+++ b/src/services/Rules.php
@@ -78,7 +78,7 @@ class Rules extends Component
     /**
      * Purge any related URLs we’ve established with custom rules.
      */
-    public function purgeCachesForUrl(string $url, bool $immediately = false): void
+    public function purgeCachesForUrl(string $url, ?string $siteHandle = null, bool $immediately = false): void
     {
         // max limit for Cloudflare API
         $cloudflareRuleCountLimit = 30;
@@ -110,10 +110,10 @@ class Rules extends Component
         }
 
         if ($immediately) {
-            Cloudflare::$plugin->api->purgeUrls($urlsToPurge);
+            Cloudflare::$plugin->api->purgeUrls($urlsToPurge, $siteHandle);
         } else {
             Queue::push(
-                new PurgeCloudflareCache(['urls' => $urlsToPurge]),
+                new PurgeCloudflareCache(['urls' => $urlsToPurge, 'siteHandle' => $siteHandle]),
                 Cloudflare::$plugin->settings->queueJobPriority,
             );
         }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -113,7 +113,7 @@
             required: true,
             name: 'zone',
             options: zoneOptions,
-            value: settings.zone,
+            value: settings.getZone(requestedSite.handle),
             autofocus: true,
             errors: settings.getErrors('zone'),
             instructions: 'Specify which Cloudflare Zone is utilized by this site.'|t('cloudflare')
@@ -134,7 +134,7 @@
             required: true,
             name: 'zone',
             class: 'code',
-            value: settings.zone,
+            value: settings.getZone(requestedSite.handle),
             autofocus: true,
             errors: settings.getErrors('zone'),
             disabled: settings.zoneIsStatic(),


### PR DESCRIPTION
Utilizes Craft's native `ConfigHelper::localizedValue` to add (static) config support for different zones for multisite systems