### PR TITLE
Fix purge job progress to avoid >100% in queue UI

### DIFF
--- a/src/queue/jobs/PurgeCloudflareCache.php
+++ b/src/queue/jobs/PurgeCloudflareCache.php
@@ -19,7 +19,7 @@ class PurgeCloudflareCache extends BaseJob
     public function execute($queue): void
     {
         Cloudflare::$plugin->api->purgeUrls($this->urls);
-        $this->setProgress($queue, 100);
+        $this->setProgress($queue, 1);
     }
 
     /**


### PR DESCRIPTION
## Summary
- use Craft queue progress scale (`0..1`) in the purge job
- change `setProgress($queue, 100)` to `setProgress($queue, 1)`

## Why
Craft expects fractional progress values. Passing `100` results in progress being rendered as `10000%` in the queue UI.
